### PR TITLE
Added unit test. Deleted async data becouse it contains android context

### DIFF
--- a/app/src/main/java/com/flopezluksenberg/todo/todolist/TodoItemsRepository.kt
+++ b/app/src/main/java/com/flopezluksenberg/todo/todolist/TodoItemsRepository.kt
@@ -4,32 +4,27 @@ import android.content.SharedPreferences
 import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.flopezluksenberg.todo.TodoItem
-import org.jetbrains.anko.doAsync
-import org.jetbrains.anko.uiThread
 
-class TodoItemsRepository(private val sharedPreferences: SharedPreferences, private val objectMapper: ObjectMapper) : TodoItemsInteractor{
+class TodoItemsRepository(private val sharedPreferences: SharedPreferences, private val objectMapper: ObjectMapper) : TodoItemsInteractor {
     companion object {
         const val TODO_APP = "com.flopezluksenberg.todo.TODO_APP"
         private const val ITEMS = "items"
     }
 
-    override fun saveItems(items: List<TodoItem>){
+    override fun saveItems(items: List<TodoItem>) {
         sharedPreferences.edit().putString(ITEMS, objectMapper.writeValueAsString(items)).apply()
     }
 
-    override fun getItems(listener: TodoItemsInteractor.Listener){
-        doAsync {
-            try{
-                val itemsString = sharedPreferences.getString(ITEMS, null)
-                if(itemsString != null){
-                    uiThread { listener.onGetItemsSuccess(objectMapper.readValue(itemsString, object : TypeReference<List<TodoItem>>(){})) }
-                }else{
-                    uiThread { listener.onGetItemsNotSuccess() }
-                }
-            }catch (e: Exception){
-                uiThread { listener.onGetItemsFailure() }
+    override fun getItems(listener: TodoItemsInteractor.Listener) {
+        try {
+            val itemsString = sharedPreferences.getString(ITEMS, null)
+            if (itemsString != null) {
+                listener.onGetItemsSuccess(objectMapper.readValue(itemsString, object : TypeReference<List<TodoItem>>() {}))
+            } else {
+                listener.onGetItemsNotSuccess()
             }
-
+        } catch (e: Exception) {
+            listener.onGetItemsFailure()
         }
     }
 

--- a/app/src/main/java/com/flopezluksenberg/todo/todolist/TodoListPresenter.kt
+++ b/app/src/main/java/com/flopezluksenberg/todo/todolist/TodoListPresenter.kt
@@ -3,6 +3,7 @@ package com.flopezluksenberg.todo.todolist
 import com.flopezluksenberg.todo.TodoItem
 
 class TodoListPresenter(private var view: TodoListView?, private val interactor: TodoItemsInteractor, savedItems: List<TodoItem>? = null) : TodoItemsInteractor.Listener {
+
     init {
         view?.showLoading()
         savedItems?.apply {

--- a/app/src/test/java/com/flopezluksenberg/todo/TodoListPresenterTest.kt
+++ b/app/src/test/java/com/flopezluksenberg/todo/TodoListPresenterTest.kt
@@ -4,9 +4,10 @@ import com.flopezluksenberg.todo.todolist.TodoItemsInteractor
 import com.flopezluksenberg.todo.todolist.TodoListPresenter
 import com.flopezluksenberg.todo.todolist.TodoListView
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mock
@@ -51,5 +52,30 @@ class TodoListPresenterTest {
         presenter.addItem("Hola")
         verify(view).addTodoItem(any())
         verify(interactor).saveItems(viewItems)
+    }
+
+    @Test
+    fun when_presenter_delete_all_items_interactor_should_call_delete_all_items_method() {
+        presenter.deleteAllItems()
+        verify(interactor).deleteAllItems()
+        verify(view).showEmptyPlaceholder()
+    }
+
+    @Test
+    fun when_delete_item_should_call_delete_item_method_in_view() {
+        val todoItem = TodoItem("Saraza 1")
+        presenter.deleteItem(todoItem)
+        verify(view).deleteItem(todoItem)
+    }
+
+    @Test
+    fun when_empty_items_should_call_show_empty_placeholder_method() {
+        Mockito.`when`(view.getItems()).thenReturn(arrayListOf())
+        val todoItem = TodoItem("asdasd")
+
+        presenter.deleteItem(todoItem)
+
+        verify(view).deleteItem(todoItem)
+        verify(view).showEmptyPlaceholder()
     }
 }

--- a/app/src/test/java/com/flopezluksenberg/todo/todolist/TodoItemsRepositoryTest.kt
+++ b/app/src/test/java/com/flopezluksenberg/todo/todolist/TodoItemsRepositoryTest.kt
@@ -1,0 +1,77 @@
+package com.flopezluksenberg.todo.todolist
+
+import android.content.SharedPreferences
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.flopezluksenberg.todo.ObjectMapperHelper
+import com.flopezluksenberg.todo.TodoItem
+import com.nhaarman.mockito_kotlin.eq
+import com.nhaarman.mockito_kotlin.verify
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.MockitoAnnotations
+
+class TodoItemsRepositoryTest {
+
+    @Mock
+    private lateinit var sharedPreferences: SharedPreferences
+
+    @Mock
+    private lateinit var sharedEditor: SharedPreferences.Editor
+
+    @Mock
+    private lateinit var listener: TodoItemsInteractor.Listener
+
+    private lateinit var objectMapper: ObjectMapper
+
+    private lateinit var interactor: TodoItemsRepository
+
+    @Before
+    fun setup() {
+        MockitoAnnotations.initMocks(this)
+        Mockito.`when`(sharedPreferences.edit()).thenReturn(sharedEditor)
+        Mockito.`when`(sharedEditor.putString(eq("items"), any())).thenReturn(sharedEditor)
+
+        objectMapper = ObjectMapperHelper.getInstance()
+        interactor = TodoItemsRepository(sharedPreferences, objectMapper)
+    }
+
+    @Test
+    fun saveItems() {
+        val items = arrayListOf(TodoItem("A"), TodoItem("B"))
+        interactor.saveItems(items)
+        verify(sharedEditor).apply()
+    }
+
+    @Test
+    fun test_get_items_and_list_is_null_should_call_onGetItemsNotSuccess_listener_method() {
+        Mockito.`when`(sharedEditor.putString("items", null)).thenReturn(null)
+        interactor.getItems(listener)
+        verify(listener).onGetItemsNotSuccess()
+    }
+
+    @Test
+    fun test_get_items_and_list_has_objects_should_call_onGetItemsSuccess_listener_method() {
+        val items = arrayListOf(TodoItem("ads"))
+        Mockito.`when`(sharedPreferences.getString("items", null)).thenReturn(objectMapper.writeValueAsString(items))
+        interactor.getItems(listener)
+        verify(listener).onGetItemsSuccess(items)
+    }
+
+    @Test
+    fun test_get_items_and_list_has_wrong_mapped_objects_should_call_onGetItemsFailure_listener_method() {
+        Mockito.`when`(sharedPreferences.getString("items", null)).thenReturn("This is a wrong object mapped data")
+        interactor.getItems(listener)
+        verify(listener).onGetItemsFailure()
+    }
+
+    @Test
+    fun deleteAllItems() {
+        Mockito.`when`(sharedEditor.remove(any())).thenReturn(sharedEditor)
+        interactor.deleteAllItems()
+        verify(sharedEditor).remove("items")
+        verify(sharedEditor).apply()
+    }
+}


### PR DESCRIPTION
Tuve que sacar la parte de doAsync y uiThread en el interactor, debido a que eso contiene parte del context de android, por lo que no podía testear y basicamente estariamos rompiendo con el mvp (Me di cuenta haciendo esto jajaa). Creo que hay que mejorarlo un toque, pero nada grave, lo que haría es eliminar del init del presenter que haga un getItems del interactor, sino que ese getItems lo metería en un método aparte que expone el presenter y el activity lo llama haciendo un "doAsync" (es una idea). De todso modos deberíamos ver cómo hacemos para no usar en estos hilos el tema del context. Tal vez usar hilos de java a lo macho sería una solución... .... ...